### PR TITLE
Make start_replica run in foreground when log_file == stdout

### DIFF
--- a/pg_chameleon/lib/global_lib.py
+++ b/pg_chameleon/lib/global_lib.py
@@ -622,14 +622,14 @@ class replica_engine(object):
 					else:
 						foreground = False
 						print("Starting the replica process for source %s" % (self.args.source))
-						keep_fds = [self.logger_fds]
 						
-						app_name = "%s_replica" % self.args.source
-						replica_daemon = Daemonize(app=app_name, pid=replica_pid, action=self.__run_replica, foreground=foreground , keep_fds=keep_fds)
-						try:
-							replica_daemon.start()
-						except:
-							print("The replica process is already started. Aborting the command.")
+					keep_fds = [self.logger_fds]
+					app_name = "%s_replica" % self.args.source
+					replica_daemon = Daemonize(app=app_name, pid=replica_pid, action=self.__run_replica, foreground=foreground , keep_fds=keep_fds)
+					try:
+						replica_daemon.start()
+					except:
+						print("The replica process is already started. Aborting the command.")
 				
 	
 	def __stop_replica(self):


### PR DESCRIPTION
We are running pg_chameleon in a Docker container, but the only way to currently run replication in the foreground is via `--debug`, which is extremely verbose. Looking at the source, its seemed like the intention here was for setting `log_file` to `stdout` to be another way of doing this, but it wasn't executing the actual replication process - so I just changed the indentation to take it out of the else block.