### PR TITLE
Fix for limited amount of tables

### DIFF
--- a/pg_chameleon/lib/mysql_lib.py
+++ b/pg_chameleon/lib/mysql_lib.py
@@ -1097,6 +1097,7 @@ class mysql_source(object):
 			resume_stream = True, 
 			only_schemas = self.schema_replica, 
 			slave_heartbeat = self.sleep_loop, 
+			only_tables= self.limit_tables[self.schema_replica[0]]
 			
 		)
 		if gtid_set:


### PR DESCRIPTION
This will fix hanging of stream reader on null updates to excluded tables.
It should also speed up a little, because we will filter out unnecessary tables.

I am not sure if this change works with full schema updates