### PR TITLE
Fetch event rows only for tables being replicated.

### DIFF
--- a/pg_chameleon/lib/mysql_lib.py
+++ b/pg_chameleon/lib/mysql_lib.py
@@ -1240,21 +1240,21 @@ class mysql_source(object):
 					return [master_data, close_batch]
 			else:
 
-				for row in binlogevent.rows:
-					event_after={}
-					event_before={}
-					event_insert = {}
-					add_row = True
-					log_file=binlogfile
-					log_position=binlogevent.packet.log_pos
-					table_name=binlogevent.table
-					event_time=binlogevent.timestamp
-					schema_row = binlogevent.schema
-					destination_schema = self.schema_mappings[schema_row]
-					table_key_dic = "%s.%s" % (destination_schema, table_name)
-					store_row = self.__store_binlog_event(table_name, schema_row)
-					skip_event = self.__skip_event(table_name, schema_row, binlogevent)
-					if store_row and not skip_event[0]:
+				table_name=binlogevent.table
+				event_time=binlogevent.timestamp
+				schema_row = binlogevent.schema
+				skip_event = self.__skip_event(table_name, schema_row, binlogevent)
+				store_row = self.__store_binlog_event(table_name, schema_row)
+				if store_row and not skip_event[0]:
+					for row in binlogevent.rows:
+						event_after={}
+						event_before={}
+						event_insert = {}
+						add_row = True
+						log_file=binlogfile
+						log_position=binlogevent.packet.log_pos
+						destination_schema = self.schema_mappings[schema_row]
+						table_key_dic = "%s.%s" % (destination_schema, table_name)
 						if table_key_dic in inc_tables:
 							table_consistent = False
 							log_seq = int(log_file.split('.')[1])


### PR DESCRIPTION
pymysqlreplication does not support MariaDB-exclusive binary formats, e.g. the high-res datetime format used before 10.1.2. In these cases, attempting to fetch rows from a binlog event will result in a runtime error. I was running into this even **after** migrating my tables to use the new MySQL-compatible datetime format. After a bit of debugging, it turned out the culprit was another table with an old datetime column - even though my pg_chameleon was configured to ignore this table, it was still attempting to parse the event rows.

This PR is avoid this by only attempting to parse row data *after* determining whether or not the row event should be skipped, so it allows compatibility with MariaDB databases that have unsupported columns so long as they are not in the tables being replicated.