### PR TITLE
mysql-replication support for PyMySQL>0.10.0 was introduced in v0.22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     ],
     install_requires=[
         'PyMySQL>=0.10.0',
-        'mysql-replication<0.27',
+        'mysql-replication<0.27,>=0.22',
         'psycopg2-binary>=2.8.3',
         'PyYAML>=3.13',
         'tabulate>=0.8.1',


### PR DESCRIPTION
This might not be the way to safeguard against it, but for illustration, my upgrade of pg_chameleon to 2.0.18 pulled in version ```0.21``` of ```mysql-replication``` and ```0.10.1``` of ```PyMySQL```
This resulted in ```charset_to_encoding``` errors which were addressed in [version 0.22](https://github.com/julien-duponchelle/python-mysql-replication/commit/51ac1dbd6b18ebc8000624f96e7ec601239ef3b7) of ```mysql-replication```.

A manual bump of ```mysql-replication==0.22``` fixed this for me.
If the requirement could be expressed in the package that would be nice.
