### PR TITLE
Rewrite in parsy instead of regular expressions

### DIFF
--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -260,7 +260,7 @@ class sql_token(object):
         if index_name in {"FOREIGN", "OTHER"}:
             return None
         elif index_name == "PRIMARY":
-            return dict(index_name=index_name, index_columns=index_columns, non_unique=0)
+            return dict(index_name="PRIMARY", index_columns=index_columns, non_unique=0)
         elif index_name == "UNIQUE":
             return dict(
                 index_name=f"ukidx_{table_name[0:20]}_{idx_counter}",

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -4,11 +4,26 @@ from parsy import alt, any_char, digit, seq, string, regex, whitespace
 
 
 def ci_string(s):
+    """
+    This function creates a case-insensitive parser for a string
+
+    :param s: the string to make a case-insensitive parser for.
+    :return: case-insensitive parser for string s
+    :rtype: parsy.Parser
+    """
     return string(s.upper(), transform=lambda x: x.upper()).result(s)
 
 
-def optional_space_around(s):
-    return whitespace.optional() >> s << whitespace.optional()
+def optional_space_around(p):
+    """
+    This function creates extends an existing parser with optional whitespace
+    around it. Whitespace is stripped from the parser's result.
+
+    :param p: the parser to extend
+    :return: a new parser with optional whitespace around it
+    :rtype: parsy.Parser
+    """
+    return whitespace.optional() >> p << whitespace.optional()
 
 
 pgsql_identifier = regex("\w+")
@@ -34,6 +49,21 @@ ignored_by_column_def = alt(
 )
 
 def post_process_column_definition(column_name, data_type, dimensions, enum_list, extras):
+    """
+    This function does some operations on the parts identified by the column_definition parser
+    to make it according to the expected col_dic format. This includes extracting dimensions,
+    separating different constraints into their own key, etc.
+
+    The arguments accepted are the ones parsed by the column_definition parser.
+
+    :param column_name: column_name as parsed by the column definition parser
+    :param data_type: data_type as parsed by the column definition parser
+    :param dimensions: the numeric dimensions defined as part of the column type
+    :param enum_list: the enum list defined as part of the column type
+    :param extras: other modifiers to the column
+    :returns: column dictionary which conforms to the col_dic format
+    :rtype: dictionary
+    """
     col_dict = dict(column_name=column_name, data_type=data_type)
 
     col_dict["is_nullable"] = "NO" if "NOT NULL" in extras else "YES"

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -16,7 +16,7 @@ def ci_string(s):
 
 def optional_space_around(p):
     """
-    This function creates extends an existing parser with optional whitespace
+    This function extends an existing parser with optional whitespace
     around it. Whitespace is stripped from the parser's result.
 
     :param p: the parser to extend
@@ -50,9 +50,22 @@ ignored_by_column_def = alt(
 
 def post_process_column_definition(column_name, data_type, dimensions, enum_list, extras):
     """
-    This function does some operations on the parts identified by the column_definition parser
-    to make it according to the expected col_dic format. This includes extracting dimensions,
-    separating different constraints into their own key, etc.
+    This function does uses the parts identified by the column_definition parser
+    and builds a dictionary in the col_dic format. It adds fields that are not identified
+    directly by the parser.
+
+    ```
+    col_dic format:
+      column_name: str
+      data_type: str
+      is_nullable: enum "YES"|"NO"
+      enum_list: maybe str
+      character_maximum_length: maybe str
+      numeric_precision: maybe str
+      numeric_scale: maybe str | int (defaults to 0)
+      extra: str
+      column_type: str
+    ```
 
     The arguments accepted are the ones parsed by the column_definition parser.
 
@@ -85,16 +98,6 @@ def post_process_column_definition(column_name, data_type, dimensions, enum_list
     return col_dict
 
 
-# col_dic:
-#  column_name: str
-#  data_type: str
-#  is_nullable: enum "YES"|"NO"
-#  enum_list: maybe str
-#  character_maximum_length: maybe str
-#  numeric_precision: maybe str
-#  numeric_scale: maybe str | int (defaults to 0)
-#  extra: str
-#  column_type: str
 column_definition = seq(
     column_name=identifier,
     data_type=whitespace >> ci_word.map(lambda x: x.lower()),

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -151,7 +151,7 @@ create_table_statement = seq(
     command=(ci_string("CREATE") >> whitespace >> ci_string("TABLE")).result("CREATE TABLE"),
     __if_not_exists=seq(
         whitespace, ci_string("IF"),
-        whitespace, ci_string("NOT").optional(),
+        whitespace, ci_string("NOT"),
         whitespace, ci_string("EXISTS")
     ).optional(),
     name=whitespace >> identifier,

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -4,7 +4,7 @@ from parsy import alt, any_char, digit, seq, string, regex, whitespace
 
 
 def ci_string(s):
-    return string(s, transform=lambda x: x.upper())
+    return string(s.upper(), transform=lambda x: x.upper()).result(s)
 
 
 def optional_space_around(s):

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         'PyYAML>=3.13',
         'tabulate>=0.8.1',
         'daemonize>=2.4.7',
-        'rollbar>=0.13.17'
+        'rollbar>=0.13.17',
+        'parsy>=2.1'
     ],
     include_package_data = True,
     package_data=package_data,

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Database :: Database Engines/Servers",
         "Topic :: Other/Nonlisted Topic"
     ],
@@ -62,7 +61,7 @@ setup(
     include_package_data = True,
     package_data=package_data,
     packages=setuptools.find_packages(),
-    python_requires='>=3.5',
+    python_requires='>=3.7',
     keywords='postgresql mysql replica migration database',
 
 )

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,79 +1,82 @@
 import pytest
 
 
-from pg_chameleon.lib.sql_util import any_key_definition, column_definition
+from pg_chameleon.lib.sql_util import sql_token
+
+
+tokenizer = sql_token()
 
 
 @pytest.mark.parametrize(
     "parser, string, expectation",
     [
         (
-            column_definition,
+            tokenizer.column_definition,
             "id int PRIMARY KEY",
             dict(column_name="id", data_type="int",
                  dimensions=None, enum_list=None, extras=["PRIMARY KEY"])
         ),
         (
-            any_key_definition,
+            tokenizer.any_key_definition,
             "CONSTRAINT pk_id PRIMARY KEY (id)",
             dict(index_name="PRIMARY", index_columns=["id"], non_unique=0)
         ),
         (
-            any_key_definition,
+            tokenizer.any_key_definition,
             "CONSTRAINT pk_id1_id2 PRIMARY KEY (id1,id2)",
             dict(index_name="PRIMARY", index_columns=["id1", "id2"], non_unique=0)
         ),
         (
-            any_key_definition,
+            tokenizer.any_key_definition,
             "PRIMARY\n KEY(id1, id2, `id3`, `id 4` )",
             dict(index_name="PRIMARY", index_columns=["id1", "id2", "id3", "id 4"], non_unique=0)
         ),
         (
-            any_key_definition,
+            tokenizer.any_key_definition,
             "UNIQUE KEY (id1, id2)",
             dict(index_name="UNIQUE", index_columns=["id1", "id2"], non_unique=0)
         ),
         (
-            any_key_definition,
+            tokenizer.any_key_definition,
             "UNIQUE KEY (id1)",
             dict(index_name="UNIQUE", index_columns=["id1"], non_unique=0)
         ),
         (
-            any_key_definition,
+            tokenizer.any_key_definition,
             "UNIQUE (id1, id2)",
             dict(index_name="UNIQUE", index_columns=["id1", "id2"], non_unique=0)
         ),
         (
-            any_key_definition,
+            tokenizer.any_key_definition,
             "KEY (id1)",
             dict(index_name="INDEX", index_columns=["id1"], non_unique=1)
         ),
         (
-            any_key_definition,
+            tokenizer.any_key_definition,
             "FULLTEXT KEY asdf (id)",
             dict(index_name="OTHER", index_columns=["id"], non_unique=1),
         ),
         (
-            any_key_definition,
+            tokenizer.any_key_definition,
             "FOREIGN KEY (column1) REFERENCES table2 (column2)",
             dict(index_name="FOREIGN", index_columns=["column1"], non_unique=1)
         ),
         (
-            column_definition,
+            tokenizer.column_definition,
             """film_rating smallint not null
             DEFAULT 3""",
             dict(column_name="film_rating", data_type="smallint",
                  dimensions=None, enum_list=None,
-                 extras=["NOT NULL", ["DEFAULT", ' ', "3"]])
+                 extras=["NOT NULL", ["DEFAULT", "3"]])
         ),
         (
-            column_definition,
+            tokenizer.column_definition,
             """film_rating
             ENUM ('1 star', '2 star', '3 star', '4 star', '5 star')
             DEFAULT '3 star'""",
             dict(column_name="film_rating", data_type="enum",
                  dimensions=None, enum_list=["1 star", "2 star", "3 star", "4 star", "5 star"],
-                 extras=[["DEFAULT", " ", "'3 star'"]])
+                 extras=[["DEFAULT", "'3 star'"]])
         )
     ]
 )

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,5 +1,6 @@
-import pytest
+#!/usr/bin/env python
 
+import unittest
 
 from pg_chameleon.lib.sql_util import sql_token
 
@@ -7,62 +8,61 @@ from pg_chameleon.lib.sql_util import sql_token
 tokenizer = sql_token()
 
 
-@pytest.mark.parametrize(
-    "parser, string, expectation",
-    [
+class TestTokenizer(unittest.TestCase):
+    param_list = [
         (
-            tokenizer.column_definition,
+            "column_definition",
             "id int PRIMARY KEY",
             dict(column_name="id", data_type="int",
                  dimensions=None, enum_list=None, extras=["PRIMARY KEY"])
         ),
         (
-            tokenizer.any_key_definition,
+            "any_key_definition",
             "CONSTRAINT pk_id PRIMARY KEY (id)",
             dict(index_name="PRIMARY", index_columns=["id"], non_unique=0)
         ),
         (
-            tokenizer.any_key_definition,
+            "any_key_definition",
             "CONSTRAINT pk_id1_id2 PRIMARY KEY (id1,id2)",
             dict(index_name="PRIMARY", index_columns=["id1", "id2"], non_unique=0)
         ),
         (
-            tokenizer.any_key_definition,
+            "any_key_definition",
             "PRIMARY\n KEY(id1, id2, `id3`, `id 4` )",
             dict(index_name="PRIMARY", index_columns=["id1", "id2", "id3", "id 4"], non_unique=0)
         ),
         (
-            tokenizer.any_key_definition,
+            "any_key_definition",
             "UNIQUE KEY (id1, id2)",
             dict(index_name="UNIQUE", index_columns=["id1", "id2"], non_unique=0)
         ),
         (
-            tokenizer.any_key_definition,
+            "any_key_definition",
             "UNIQUE KEY (id1)",
             dict(index_name="UNIQUE", index_columns=["id1"], non_unique=0)
         ),
         (
-            tokenizer.any_key_definition,
+            "any_key_definition",
             "UNIQUE (id1, id2)",
             dict(index_name="UNIQUE", index_columns=["id1", "id2"], non_unique=0)
         ),
         (
-            tokenizer.any_key_definition,
+            "any_key_definition",
             "KEY (id1)",
             dict(index_name="INDEX", index_columns=["id1"], non_unique=1)
         ),
         (
-            tokenizer.any_key_definition,
+            "any_key_definition",
             "FULLTEXT KEY asdf (id)",
             dict(index_name="OTHER", index_columns=["id"], non_unique=1),
         ),
         (
-            tokenizer.any_key_definition,
+            "any_key_definition",
             "FOREIGN KEY (column1) REFERENCES table2 (column2)",
             dict(index_name="FOREIGN", index_columns=["column1"], non_unique=1)
         ),
         (
-            tokenizer.column_definition,
+            "column_definition",
             """film_rating smallint not null
             DEFAULT 3""",
             dict(column_name="film_rating", data_type="smallint",
@@ -70,7 +70,7 @@ tokenizer = sql_token()
                  extras=["NOT NULL", ["DEFAULT", "3"]])
         ),
         (
-            tokenizer.column_definition,
+            "column_definition",
             """film_rating
             ENUM ('1 star', '2 star', '3 star', '4 star', '5 star')
             DEFAULT '3 star'""",
@@ -79,7 +79,16 @@ tokenizer = sql_token()
                  extras=[["DEFAULT", "'3 star'"]])
         )
     ]
-)
-def test_parses_successfully(parser, string, expectation):
-    output = parser.parse(string)
-    assert output == expectation
+
+    def test_parses_successfully(self):
+        for parser_name, string, expected in self.param_list:
+            parser = getattr(tokenizer, parser_name)
+            with self.subTest(
+                msg=f"Checking parser {parser_name}", string=string, expected=expected
+            ):
+                output = parser.parse(string)
+                self.assertEqual(output, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,82 @@
+import pytest
+
+
+from pg_chameleon.lib.sql_util import any_key_definition, column_definition
+
+
+@pytest.mark.parametrize(
+    "parser, string, expectation",
+    [
+        (
+            column_definition,
+            "id int PRIMARY KEY",
+            dict(column_name="id", data_type="int",
+                 dimensions=None, enum_list=None, extras=["PRIMARY KEY"])
+        ),
+        (
+            any_key_definition,
+            "CONSTRAINT pk_id PRIMARY KEY (id)",
+            dict(index_name="PRIMARY", index_columns=["id"], non_unique=0)
+        ),
+        (
+            any_key_definition,
+            "CONSTRAINT pk_id1_id2 PRIMARY KEY (id1,id2)",
+            dict(index_name="PRIMARY", index_columns=["id1", "id2"], non_unique=0)
+        ),
+        (
+            any_key_definition,
+            "PRIMARY\n KEY(id1, id2, `id3`, `id 4` )",
+            dict(index_name="PRIMARY", index_columns=["id1", "id2", "id3", "id 4"], non_unique=0)
+        ),
+        (
+            any_key_definition,
+            "UNIQUE KEY (id1, id2)",
+            dict(index_name="UNIQUE", index_columns=["id1", "id2"], non_unique=0)
+        ),
+        (
+            any_key_definition,
+            "UNIQUE KEY (id1)",
+            dict(index_name="UNIQUE", index_columns=["id1"], non_unique=0)
+        ),
+        (
+            any_key_definition,
+            "UNIQUE (id1, id2)",
+            dict(index_name="UNIQUE", index_columns=["id1", "id2"], non_unique=0)
+        ),
+        (
+            any_key_definition,
+            "KEY (id1)",
+            dict(index_name="INDEX", index_columns=["id1"], non_unique=1)
+        ),
+        (
+            any_key_definition,
+            "FULLTEXT KEY asdf (id)",
+            dict(index_name="OTHER", index_columns=["id"], non_unique=1),
+        ),
+        (
+            any_key_definition,
+            "FOREIGN KEY (column1) REFERENCES table2 (column2)",
+            dict(index_name="FOREIGN", index_columns=["column1"], non_unique=1)
+        ),
+        (
+            column_definition,
+            """film_rating smallint not null
+            DEFAULT 3""",
+            dict(column_name="film_rating", data_type="smallint",
+                 dimensions=None, enum_list=None,
+                 extras=["NOT NULL", ["DEFAULT", ' ', "3"]])
+        ),
+        (
+            column_definition,
+            """film_rating
+            ENUM ('1 star', '2 star', '3 star', '4 star', '5 star')
+            DEFAULT '3 star'""",
+            dict(column_name="film_rating", data_type="enum",
+                 dimensions=None, enum_list=["1 star", "2 star", "3 star", "4 star", "5 star"],
+                 extras=[["DEFAULT", " ", "'3 star'"]])
+        )
+    ]
+)
+def test_parses_successfully(parser, string, expectation):
+    output = parser.parse(string)
+    assert output == expectation


### PR DESCRIPTION
This pull request implements some part of parser for the "create table" with use of the parsy library, to validate whether it can be used to rewrite the whole parser. The goal is to make it easier to modify the code, which right now uses complicated regular expressions to get the job done.

All primitives and operations used are documented on these two pages:
- [Primitives](https://parsy.readthedocs.io/en/latest/ref/primitives.html)
- [Methods, operators, and combinators](https://parsy.readthedocs.io/en/latest/ref/methods_and_combinators.html)

**Changelog:**
- Add `ci_string` and `optional_space_around` functions for creating parsers
- Implement column definition parser in parsy
- Modify parse_column to use the column definition parser instead of the previous `field_re` regular expression and python logic.
- Convert all regular expressions to parsers written in parsy
- Fix bug when white space in enum strings was not considered part of the string (more robust parsing of sql strings and terms inside parentheses)
- Rewrite normalization from find-and-replace logic to only 2 find-and-replace substitutions for removing comments from the sql string