### PR TITLE
ignore alter index statements as per the old behaviour

### DIFF
--- a/pg_chameleon/lib/pg_lib.py
+++ b/pg_chameleon/lib/pg_lib.py
@@ -1312,6 +1312,7 @@ class pg_engine(object):
             CREATE TABLE
             ALTER TABLE
             DROP PRIMARY KEY
+            CREATE INDEX
 
             :param token: A dictionary with the tokenised sql statement
             :param destination_schema: The ddl destination schema mapped from the mysql corresponding schema
@@ -1347,7 +1348,9 @@ class pg_engine(object):
                     query=""" DROP TABLE IF EXISTS "%s"."%s";""" % (destination_schema, token["name"])
                 elif token["command"] == "TRUNCATE":
                     query=""" TRUNCATE TABLE "%s"."%s" CASCADE;""" % (destination_schema, token["name"])
-
+                elif token["command"] == "CREATE INDEX":
+                    table_name, index_data = token["name"], token["indices"]
+                    query=self.build_create_index(destination_schema, token["name"], index_data)
                 elif token["command"] == "ALTER TABLE":
                     query=self.build_alter_table(destination_schema, token)
                 elif token["command"] == "DROP PRIMARY KEY":

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -192,15 +192,16 @@ class sql_token(object):
         optional_space_around(rename_table_item).sep_by(string(","))
     ).combine_dict(dict)
 
+    # NOTE: ignored
     # ALTER TABLE table_name {ADD | DROP} [UNIQUE] INDEX [... rest]
     alter_index_statement = seq(
-        command=seq(ci_string("ALTER"), whitespace, ci_string("TABLE")).result("ALTER INDEX"),
-        name=whitespace >> identifier,
-        action=whitespace >> (ci_string("ADD") | ci_string("DROP")),
-        __unique=(whitespace >> ci_string("UNIQUE")).optional(),
-        __index=whitespace >> ci_string("INDEX"),
-        __rest=any_char.many(),
-    ).combine_dict(dict)
+        seq(ci_string("ALTER"), whitespace, ci_string("TABLE")).result("ALTER INDEX"),
+        whitespace >> identifier,
+        whitespace >> (ci_string("ADD") | ci_string("DROP")),
+        (whitespace >> ci_string("UNIQUE")).optional(),
+        whitespace >> ci_string("INDEX"),
+        any_char.many(),
+    ).result(None)
 
     # DROP TABLE [IF EXISTS] table_name
     drop_table_statement = seq(


### PR DESCRIPTION
* Ignore `ALTER TABLE [ADD | DROP] [UNIQUE] INDEX ...` statements as per the old behaviour

Before this commit, this parser would emit a `{"command": "ALTER INDEX", "name": "table_name", "action": "ADD"}` kind of dictionary for this statement, but the behaviour before adding parsy was different and this is to be ignored.

The mysql_source doesn't yet know how to make sense of this. This can be supported similarly to the `CREATE INDEX` statements.