### PR TITLE
Add support for creating, altering, and dropping indices

### DIFF
--- a/pg_chameleon/lib/pg_lib.py
+++ b/pg_chameleon/lib/pg_lib.py
@@ -1312,7 +1312,6 @@ class pg_engine(object):
             CREATE TABLE
             ALTER TABLE
             DROP PRIMARY KEY
-            CREATE INDEX
 
             :param token: A dictionary with the tokenised sql statement
             :param destination_schema: The ddl destination schema mapped from the mysql corresponding schema
@@ -1348,9 +1347,6 @@ class pg_engine(object):
                     query=""" DROP TABLE IF EXISTS "%s"."%s";""" % (destination_schema, token["name"])
                 elif token["command"] == "TRUNCATE":
                     query=""" TRUNCATE TABLE "%s"."%s" CASCADE;""" % (destination_schema, token["name"])
-                elif token["command"] == "CREATE INDEX":
-                    table_name, index_data = token["name"], token["indices"]
-                    query=self.build_create_index(destination_schema, token["name"], index_data)
                 elif token["command"] == "ALTER TABLE":
                     query=self.build_alter_table(destination_schema, token)
                 elif token["command"] == "DROP PRIMARY KEY":

--- a/pg_chameleon/lib/pg_lib.py
+++ b/pg_chameleon/lib/pg_lib.py
@@ -1312,6 +1312,7 @@ class pg_engine(object):
             CREATE TABLE
             ALTER TABLE
             DROP PRIMARY KEY
+            CREATE INDEX
 
             :param token: A dictionary with the tokenised sql statement
             :param destination_schema: The ddl destination schema mapped from the mysql corresponding schema
@@ -1347,7 +1348,9 @@ class pg_engine(object):
                     query=""" DROP TABLE IF EXISTS "%s"."%s";""" % (destination_schema, token["name"])
                 elif token["command"] == "TRUNCATE":
                     query=""" TRUNCATE TABLE "%s"."%s" CASCADE;""" % (destination_schema, token["name"])
-
+                elif token["command"] == "CREATE INDEX":
+                    table_name, index_data = token["name"], token["indices"]
+                    query=self.build_create_index(destination_schema, token["name"], index_data)
                 elif token["command"] == "ALTER TABLE":
                     query=self.build_alter_table(destination_schema, token)
                 elif token["command"] == "DROP PRIMARY KEY":

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -192,15 +192,16 @@ class sql_token(object):
         optional_space_around(rename_table_item).sep_by(string(","))
     ).combine_dict(dict)
 
+    # NOTE: ignored
     # ALTER TABLE table_name {ADD | DROP} [UNIQUE] INDEX [... rest]
     alter_index_statement = seq(
-        command=seq(ci_string("ALTER"), whitespace, ci_string("TABLE")).result("ALTER INDEX"),
-        name=whitespace >> identifier,
-        action=whitespace >> (ci_string("ADD") | ci_string("DROP")),
-        __unique=(whitespace >> ci_string("UNIQUE")).optional(),
-        __index=whitespace >> ci_string("INDEX"),
-        __rest=any_char.many(),
-    ).combine_dict(dict)
+        seq(ci_string("ALTER"), whitespace, ci_string("TABLE")).result("ALTER INDEX"),
+        whitespace >> identifier,
+        whitespace >> (ci_string("ADD") | ci_string("DROP")),
+        (whitespace >> ci_string("UNIQUE")).optional(),
+        whitespace >> ci_string("INDEX"),
+        any_char.many(),
+    ).result(None)
 
     # DROP TABLE [IF EXISTS] table_name
     drop_table_statement = seq(

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -270,8 +270,8 @@ class sql_token(object):
         __from_schema=(identifier >> string(".")).optional(),
         name=identifier,
         __to=whitespace >> ci_string("TO"),
-        __to_schema=(whitespace >> identifier >> string(".")).optional(),
-        new_name=whitespace >> identifier,
+        __to_schema=whitespace >> (identifier >> string(".")).optional(),
+        new_name=identifier,
     ).combine_dict(dict)
 
     # RENAME TABLE ( [old_schema.]old_name TO [new_schema.]new_name )
@@ -749,10 +749,9 @@ class sql_token(object):
         """
         sql_string_cleanup = re.sub(r'/\*.*?\*/', '', sql_string, re.DOTALL)
         sql_string_cleanup = re.sub(r'--.*?\n', '', sql_string_cleanup)
-        statements = sql_string_cleanup.split(';')
 
-        for statement in statements:
-            stat_dic = self.sql_parser.parse(statement)
+        multiple_sql_parser = self.sql_parser.sep_by(optional_space_around(string(";")))
+        for stat_dic in multiple_sql_parser.parse(sql_string_cleanup):
             if isinstance(stat_dic, dict) and stat_dic != {}:
                 self.tokenised.append(stat_dic)
             elif isinstance(stat_dic, list):

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -166,7 +166,7 @@ class sql_token(object):
     # {SPATIAL | FULLTEXT} {INDEX | KEY} idx_name (column_name, ...)
     other_key_definition = seq(
         __constraint=(ci_string("CONSTRAINT") >> whitespace >> identifier >> whitespace).optional(),
-        index_name=whitespace >> (ci_string("SPATIAL") | ci_string("FULLTEXT")),
+        index_name=whitespace.optional() >> (ci_string("SPATIAL") | ci_string("FULLTEXT")),
         __index_or_key=(whitespace >> (ci_string("INDEX") | ci_string("KEY"))).optional(),
         __idx_name=whitespace >> identifier,
         index_columns=parentheses_around(key_part.sep_by(comma_sep)),

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -274,7 +274,7 @@ class sql_token(object):
     rename_table_statement = (
         ci_string("RENAME") >> whitespace >> ci_string("TABLE") >>
         optional_space_around(rename_table_item).sep_by(string(","))
-    ).combine_dict(dict)
+    )
 
     # DROP TABLE [IF EXISTS] table_name
     drop_table_statement = seq(

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -231,6 +231,7 @@ class sql_token(object):
                     ci_string("DEFAULT").result("DEFAULT"),
                     whitespace >> (sql_string.map(lambda x: f"'{x}'") | ci_word)
                 ),
+                seq(ci_string("COMMENT"), whitespace, sql_string).result("COMMENT"),
                 identifier,
                 ci_word,
             ).sep_by(whitespace)

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -535,7 +535,13 @@ class sql_token(object):
         return quoted_cols
 
     def _post_process_key_definition(
-        self, index_name, index_columns, non_unique, table_name, idx_counter
+        self,
+        index_name,
+        index_columns,
+        non_unique,
+        table_name,
+        idx_counter,
+        **tags,
     ):
         """
             This function builds a new key_dic by overwriting the index_name if necessary and by
@@ -554,24 +560,32 @@ class sql_token(object):
             :param non_unique: Whether this index must enforce unique check or not
             :param table_name: The name of the table that is used to create a new index name
             :param idx_counter: An index counter that is used to create a new index name
+            :param tags: Flags such as is_functional, is_partial, is_fulltext, etc.
             :return: The transformed key dic or None
             :rtype: dictionary | None
         """
         if index_name in {"FOREIGN", "OTHER"}:
             return None
         elif index_name == "PRIMARY":
-            return dict(index_name="PRIMARY", index_columns=index_columns, non_unique=0)
+            return dict(
+                index_name="PRIMARY",
+                index_columns=index_columns,
+                non_unique=0,
+                **tags,
+            )
         elif index_name == "UNIQUE":
             return dict(
                 index_name=f"ukidx_{table_name[0:20]}_{idx_counter}",
                 index_columns=index_columns,
                 non_unique=0,
+                **tags,
             )
         elif index_name == "INDEX":
             return dict(
                 index_name=f"idx_{table_name[0:20]}_{idx_counter}",
                 index_columns=index_columns,
                 non_unique=1,
+                **tags,
             )
         else:
             raise Exception(f"Unknown index name: {index_name}")

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -276,17 +276,6 @@ class sql_token(object):
         optional_space_around(rename_table_item).sep_by(string(","))
     ).combine_dict(dict)
 
-    # NOTE: ignored
-    # ALTER TABLE table_name {ADD | DROP} [UNIQUE] INDEX [... rest]
-    alter_index_statement = seq(
-        seq(ci_string("ALTER"), whitespace, ci_string("TABLE")).result("ALTER INDEX"),
-        whitespace >> identifier,
-        whitespace >> (ci_string("ADD") | ci_string("DROP")),
-        (whitespace >> ci_string("UNIQUE")).optional(),
-        whitespace >> ci_string("INDEX"),
-        any_char.many(),
-    ).result(None)
-
     # DROP TABLE [IF EXISTS] table_name
     drop_table_statement = seq(
         command=seq(ci_string("DROP"), whitespace, ci_string("TABLE")).result("DROP TABLE"),
@@ -466,7 +455,6 @@ class sql_token(object):
                 self.truncate_table_statement,
                 self.drop_primary_key_statement,
                 self.create_index_statement,
-                self.alter_index_statement,
                 self.alter_table_statement,
             ).optional()
         )

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -474,9 +474,11 @@ class sql_token(object):
         # supported statements
         # RENAME TABLE
         # CREATE TABLE
-        # DROP [TABLE]
-        # TRUNCATE [TABLE]
+        # DROP TABLE
+        # TRUNCATE TABLE
         # ALTER TABLE
+        # CREATE INDEX
+        # DROP INDEX
         self.sql_parser = optional_space_around(
             alt(
                 self.rename_table_statement,

--- a/pg_chameleon/lib/sql_util.py
+++ b/pg_chameleon/lib/sql_util.py
@@ -47,7 +47,7 @@ number = digit.many().concat()
 lparen = string("(")
 rparen = string(")")
 semicolon = string(";")
-comma_sep = whitespace.optional() >> string(",") << whitespace.optional()
+comma_sep = optional_space_around(string(","))
 sql_string = (
     # single-quoted string
     (string("'") >> (string(r"\'") | any_char).until(string("'")).concat() << string("'")) |
@@ -211,12 +211,16 @@ class sql_token(object):
         ).optional(),
         dimensions=(
             optional_space_around(lparen) >>
-            number.sep_by(optional_space_around(string(",") | string("|")))
+            number.sep_by(
+                comma_sep | optional_space_around(string("|"))
+            )
             << optional_space_around(rparen)
         ).optional(),
         enum_list=(
             optional_space_around(lparen) >>
-            sql_string.sep_by(optional_space_around(string(",") | string("|")))
+            sql_string.sep_by(
+                comma_sep | optional_space_around(string("|"))
+            )
             << optional_space_around(rparen)
         ).optional(),
         extras=(
@@ -341,8 +345,10 @@ class sql_token(object):
     alter_table_add_multiple = seq(
         command=ci_string("ADD").result("ADD MULTIPLE"),
         __column=(whitespace >> ci_string("COLUMN")).optional(),
-        col_defs=whitespace >> parentheses_around(
-            column_definition_in_alter_table.sep_by(optional_space_around(string(",")))
+        col_defs=optional_space_around(
+            parentheses_around(
+                column_definition_in_alter_table.sep_by(comma_sep)
+            )
         ),
     ).combine_dict(dict)
 


### PR DESCRIPTION
Right now, creating indices is only being done automatically from the `CREATE TABLE` statements. This pull request aims to change that and allow adding indices to existing tables. 

* Optional support for ALTER INDEX (maybe configurable?)

Parser changes:
* [x] Support for functional indices: `is_functional` flag in key_dic
* [x] Support for partial indices: `is_partial` flag in key_dic
* [x] Support for fulltext or spatial indices: `is_fulltext` or `is_partial` flag in key_dic
* [x] Support for detecting index type: `index_type` in key_dic as either BTREE or HASH.
* [x] Support `CREATE INDEX`
* [x] Support `ALTER TABLE ADD INDEX`
* [x] Support `ALTER TABLE RENAME INDEX`
* [x] Support `ALTER TABLE DROP INDEX`
* [x] Support `DROP INDEX`

### Open questions

- What should the default for `index_type` be? I'm setting it to `None` for now.