### PR TITLE
Fix read and replay daemons death detection

### DIFF
--- a/pg_chameleon/lib/global_lib.py
+++ b/pg_chameleon/lib/global_lib.py
@@ -588,7 +588,10 @@ class replica_engine(object):
                 self.logger.debug("Replica process for source %s is running" % (self.args.source))
                 self.pg_engine.cleanup_replayed_batches()
             else:
-                stack_trace = queue.get()
+                try:
+                    stack_trace = queue.get_nowait()
+                except:
+                    stack_trace = 'Stack trace not available'
                 self.logger.error("Read process alive: %s - Replay process alive: %s" % (read_alive, replay_alive, ))
                 self.logger.error("Stack trace: %s" % (stack_trace, ))
                 if read_alive:


### PR DESCRIPTION
## Description

A `multiprocessing` empty queue was causing an infinite wait in the daemon main loop if the read_daemon and/or replay_daemon were killed, preventing the issue detection and any remediation. The main process and the eventual remaining child process were staying running while the replication was no longer working from a global point of view.

Not digged into why the queue is empty, perhaps it deserves another investigation in another issue or PR?
