### PR TITLE
fix issue-111

### DIFF
--- a/pg_chameleon/lib/mysql_lib.py
+++ b/pg_chameleon/lib/mysql_lib.py
@@ -1366,6 +1366,9 @@ class mysql_source(object):
 
                     sql_tokeniser.reset_lists()
                 if close_batch:
+                    if len(group_insert) > 0:
+                        self.logger.debug("writing the remaining %s row events when the statement event occurs" % (len(group_insert),))
+                        self.pg_engine.write_batch(group_insert)
                     my_stream.close()
                     return [master_data, close_batch]
             else:


### PR DESCRIPTION
Based on my testing, if a large MySQL transaction is executed, the number of binlog entries pulled can be greater than the replicate_batch_size. In this case, the subsequent begin query events will discard the remaining insert groups of data after the replicat log  batch inserted.
rel-issue:https://github.com/the4thdoctor/pg_chameleon/issues/111