### PR TITLE
Ignore MySQL indices with prefix key parts

### DIFF
--- a/pg_chameleon/lib/mysql_lib.py
+++ b/pg_chameleon/lib/mysql_lib.py
@@ -786,6 +786,7 @@ class mysql_source(object):
                 table_name,
                 non_unique,
                 index_name
+            HAVING SUM(sub_part IS NOT NULL) = 0
             ;
         """
 


### PR DESCRIPTION
Btree indices on prefix keys (e.g. col_name(5) meaning the first 5 characters of "col_name") were previously being replicated as indices on the full column. This can cause errors in the case of columns with values too wide to fit in indices; and regardless produces a non-equivalent schema on the target.

PostgreSQL doesn't seem to have a direct equivalent for this type of index, so my fix is just to ignore these indices, as is done for non-BTREE indices.