### PR TITLE
Skip SAVEPOINT statements 

### DIFF
--- a/pg_chameleon/lib/mysql_lib.py
+++ b/pg_chameleon/lib/mysql_lib.py
@@ -17,7 +17,7 @@ class mysql_source(object):
             Class constructor, the method sets the class variables and configure the
             operating parameters from the args provided t the class.
         """
-        self.statement_skip = ['^BEGIN$', '^COMMIT$', '^SAVEPOINT.*$']
+        self.statement_skip = ('BEGIN', 'COMMIT', 'SAVEPOINT')
         self.schema_tables = {}
         self.schema_mappings = {}
         self.schema_loading = {}
@@ -1324,7 +1324,7 @@ class mysql_source(object):
                     schema_query = binlogevent.schema.decode()
                 except:
                     schema_query = binlogevent.schema
-                if not any(re.search(pattern, binlogevent.query.strip(), re.IGNORECASE) for pattern in self.statement_skip) and schema_query in self.schema_mappings:
+                if not binlogevent.query.strip().upper().startswith(self.statement_skip) and schema_query in self.schema_mappings:
                     close_batch=True
                     destination_schema = self.schema_mappings[schema_query]
                     log_position = binlogevent.packet.log_pos

--- a/pg_chameleon/lib/mysql_lib.py
+++ b/pg_chameleon/lib/mysql_lib.py
@@ -17,7 +17,7 @@ class mysql_source(object):
             Class constructor, the method sets the class variables and configure the
             operating parameters from the args provided t the class.
         """
-        self.statement_skip = ['BEGIN', 'COMMIT']
+        self.statement_skip = ['BEGIN', 'COMMIT', 'SAVEPOINT']
         self.schema_tables = {}
         self.schema_mappings = {}
         self.schema_loading = {}

--- a/pg_chameleon/lib/mysql_lib.py
+++ b/pg_chameleon/lib/mysql_lib.py
@@ -1324,6 +1324,7 @@ class mysql_source(object):
                     schema_query = binlogevent.schema.decode()
                 except:
                     schema_query = binlogevent.schema
+
                 if not binlogevent.query.strip().upper().startswith(self.statement_skip) and schema_query in self.schema_mappings:
                     close_batch=True
                     destination_schema = self.schema_mappings[schema_query]

--- a/pg_chameleon/lib/mysql_lib.py
+++ b/pg_chameleon/lib/mysql_lib.py
@@ -17,7 +17,7 @@ class mysql_source(object):
             Class constructor, the method sets the class variables and configure the
             operating parameters from the args provided t the class.
         """
-        self.statement_skip = ['BEGIN', 'COMMIT', 'SAVEPOINT']
+        self.statement_skip = ['^BEGIN$', '^COMMIT$', '^SAVEPOINT.*$']
         self.schema_tables = {}
         self.schema_mappings = {}
         self.schema_loading = {}
@@ -1324,8 +1324,7 @@ class mysql_source(object):
                     schema_query = binlogevent.schema.decode()
                 except:
                     schema_query = binlogevent.schema
-
-                if binlogevent.query.strip().upper() not in self.statement_skip and schema_query in self.schema_mappings:
+                if not any(re.search(pattern, binlogevent.query.strip(), re.IGNORECASE) for pattern in self.statement_skip) and schema_query in self.schema_mappings:
                     close_batch=True
                     destination_schema = self.schema_mappings[schema_query]
                     log_position = binlogevent.packet.log_pos


### PR DESCRIPTION
When we run this query with a schema (database) context `test`:
```
  docker compose exec pxc-web01 mysql test -uroot -proot -e '
  START TRANSACTION;
  INSERT INTO test.replicate_me VALUES ();
  SAVEPOINT `f34ee134-72e2-43b2-8b0d-1465a63fa071-savepoint-2`
  COMMIT;
  '
```

pg_chameleon cannot process an event with SAVEPOINT in the query:
```
2025-03-06 15:34:53 read_replica INFO mysql_lib.py (1339): QUERY EVENT - binlogfile mysql-bin.000003, position 2294040.
--------
SAVEPOINT `f34ee134-72e2-43b2-8b0d-1465a63fa071-savepoint-2`
-------- 
2025-03-06 15:34:54 MainProcess ERROR global_lib.py (609): Read process alive: False - Replay process alive: True
2025-03-06 15:34:54 MainProcess ERROR global_lib.py (610): Stack trace: Traceback (most recent call last):
  File "/pg_chameleon/pg_chameleon/lib/global_lib.py", line 535, in read_replica
    self.mysql_source.read_replica()
  File "/pg_chameleon/pg_chameleon/lib/mysql_lib.py", line 1527, in read_replica
    replica_data=self.__read_replica_stream(batch_data)
  File "/pg_chameleon/pg_chameleon/lib/mysql_lib.py", line 1340, in __read_replica_stream
    sql_tokeniser.parse_sql(binlogevent.query)
  File "/pg_chameleon/pg_chameleon/lib/sql_util.py", line 768, in parse_sql
    for stat_dic in multiple_sql_parser.parse(sql_string_cleanup):
  File "/home/chameleon/.local/lib/python3.10/site-packages/parsy/__init__.py", line 98, in parse
    (result, _) = (self << eof).parse_partial(stream)
  File "/home/chameleon/.local/lib/python3.10/site-packages/parsy/__init__.py", line 112, in parse_partial
    raise ParseError(result.expected, stream, result.furthest)
parsy.ParseError: expected one of ';', 'ALTER', 'CREATE', 'DROP', 'EOF', 'RENAME', 'TRUNCATE', '\\s+' at 0:0

2025-03-06 15:34:54 MainProcess ERROR global_lib.py (616): Read daemon crashed. Terminating the replay daemon.
```

The event object looks like this in pg_chameleon: 
```
{'_ctl_connection': <pymysql.connections.Connection object at 0x7ffffc1e2da0>,
 '_fail_on_table_metadata_unavailable': False,
 '_ignore_decode_errors': False,
 '_is_event_valid': None,
 '_processed': True,
 '_verify_checksum': False,
 'auto_increment_increment': 3,
 'auto_increment_offset': 1,
 'catalog_nz_code': b'std',
 'character_set_client': 8,
 'collation_connection': 8,
 'collation_server': 8,
 'complete': True,
 'error_code': 0,
 'event_size': 109,
 'event_type': 2,
 'execution_time': 0,
 'flags2': 0,
 'mysql_version': (0, 0, 0),
 'packet': <pymysqlreplication.packet.BinLogPacketWrapper object at 0x7ffffc1e3280>,
 'query': 'SAVEPOINT `f34ee134-72e2-43b2-8b0d-1465a63fa071-savepoint-2`',
 'schema': b'test',
 'schema_length': 4,
 'slave_proxy_id': 7818,
 'sql_mode': 1436549152,
 'status_vars_length': 31,
 'table_map': {},
 'timestamp': 1741273432}
```

Tested on:  myql 5.7.44-48-57-log with mysql-replication==0.46