### PR TITLE
remove extra slash

### DIFF
--- a/pg_chameleon/lib/global_lib.py
+++ b/pg_chameleon/lib/global_lib.py
@@ -225,7 +225,7 @@ class replica_engine(object):
         """
             The method loads the configuration from the file specified in the args.config parameter.
         """
-        local_confdir = "%s/.pg_chameleon/configuration/" % os.path.expanduser('~')
+        local_confdir = "%s/.pg_chameleon/configuration" % os.path.expanduser('~')
         self.config_file = '%s/%s.yml'%(local_confdir, self.args.config)
 
         if not os.path.isfile(self.config_file):


### PR DESCRIPTION
solves https://github.com/the4thdoctor/pg_chameleon/issues/99

current behavior:
```
❮ chameleon show_status
/home/inter/Dev/pg_chameleon/.direnv/python-3.13/bin/chameleon.py:2: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution
**FATAL - configuration file missing. Please ensure the file /home/inter/.pg_chameleon/configuration//default.yml is present.
```

desired behavior:
```
chameleon show_status
/home/inter/Dev/pg_chameleon/.direnv/python-3.13/bin/chameleon.py:2: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution
**FATAL - configuration file missing. Please ensure the file /home/inter/.pg_chameleon/configuration/default.yml is present.
```