### PR TITLE
Fix __create_indices: escape backslash inside triple quoted string

### DIFF
--- a/pg_chameleon/lib/pg_lib.py
+++ b/pg_chameleon/lib/pg_lib.py
@@ -407,7 +407,7 @@ class pgsql_source(object):
                     THEN
                         format('ALTER TABLE %%I ADD CONSTRAINT %%I %%s ;',tab.relname,con.conname,pg_get_constraintdef(con.oid))
                     ELSE
-                        format('%%s ;',regexp_replace(pg_get_indexdef(idx.oid), '("?\w+"?\.)', ''))
+                        format('%%s ;',regexp_replace(pg_get_indexdef(idx.oid), '("?\\w+"?\\.)', ''))
                 END AS ddl_text,
                 CASE
                     WHEN con.conname IS NOT NULL


### PR DESCRIPTION
Noticed a warning when running the application from source that looked like this:
```
pg_chameleon/lib/pg_lib.py:404: SyntaxWarning: invalid escape sequence '\w'
  sql_get_idx = """
```
The backslash inside the triple quoted string needs to be escaped with another backslash per how python works.

thank you for this great software!