### PR TITLE
Fix error when initiating replication with a table that has no primary key

### DIFF
--- a/pg_chameleon/lib/pg_lib.py
+++ b/pg_chameleon/lib/pg_lib.py
@@ -3878,7 +3878,7 @@ class pg_engine(object):
             binlog_pos = None
 
 
-        if len(table_pkey) > 0:
+        if (table_pkey is not None and len(table_pkey)) > 0:
             sql_insert = """
                 INSERT INTO sch_chameleon.t_replica_tables
                     (


### PR DESCRIPTION
When trying to replicate a schema that has tables without primary keys I get an error like this:
```
2026-01-28 14:52:06 MainProcess INFO mysql_lib.py (844): Could not copy the table klwgc_fields_values. Excluding it from the replica.
2026-01-28 14:52:06 MainProcess CRITICAL mysql_lib.py (1597): init replica for source mariadb failed
Traceback (most recent call last):
  File "/work/pg_chameleon/scripts/chameleon.py", line 58, in <module>
    getattr(replica, args.command)()
  File "/work/pg_chameleon/pg_chameleon/lib/global_lib.py", line 371, in init_replica
    self.__init_mysql_replica()
  File "/work/pg_chameleon/pg_chameleon/lib/global_lib.py", line 381, in __init_mysql_replica
    self.mysql_source.init_replica()
  File "/work/pg_chameleon/pg_chameleon/lib/mysql_lib.py", line 1573, in init_replica
    self.__copy_tables()
  File "/work/pg_chameleon/pg_chameleon/lib/mysql_lib.py", line 838, in __copy_tables
    self.pg_engine.store_table(destination_schema, table, table_pkey, master_status)
  File "/work/pg_chameleon/pg_chameleon/lib/pg_lib.py", line 3883, in store_table
    if len(table_pkey) > 0:
       ^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```
By adding a check for `None` the replication works for me.